### PR TITLE
Fixed refresh on number submission

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function main() {
 
   $('#years').addEventListener('input', updateTable);
 
-  $('#submit-and-continue').addEventListener('click', () => {
+  $('#submit-and-continue').addEventListener('click', (evt) => {
+      evt.preventDefault();
     STATE.submitted = true;
     $('#submit-and-continue').disabled = true;
   });


### PR DESCRIPTION
Added preventDefault onto submission event handler such that the whole page does not refresh after a single response is submitted.